### PR TITLE
Sector feature

### DIFF
--- a/mimosa/components/emissions.py
+++ b/mimosa/components/emissions.py
@@ -82,17 +82,19 @@ def get_constraints(m: AbstractModel) -> Sequence[GeneralConstraint]:
             ),
             #sector-feature
             RegionalConstraint(
-                lambda m, t, r: m.baseline_industry[t,r] == m.industry_scaling_baseline * m.baseline[t,r]
+                lambda m, t, r: m.baseline_industry[t,r] == m.industry_scaling_baseline * m.baseline[t,r],
+                "regional industry baseline emissions",
             ),
             #sector-feature
             RegionalConstraint(
-                lambda m, t, r: m.baseline_other[t,r] == (1 - m.industry_scaling_baseline) * m.baseline[t,r]
+                lambda m, t, r: m.baseline_other[t,r] == (1 - m.industry_scaling_baseline) * m.baseline[t,r],
+                "regional other baseline emissions",
             ),
             #sector-feature
             GlobalConstraint(
                 lambda m, t: m.global_emissions_industry[t]
                 == sum(m.baseline_industry[t,r] for r in m.regions),
-                "temporary_industry_emissions",
+                "global industry emissions",
             ),
             # Regional emissions from baseline and relative abatement
             RegionalConstraint(

--- a/mimosa/components/emissiontrade/notrade.py
+++ b/mimosa/components/emissiontrade/notrade.py
@@ -33,7 +33,9 @@ def get_constraints(m: AbstractModel) -> Sequence[GeneralConstraint]:
         [
             RegionalConstraint(
                 lambda m, t, r: (m.mitigation_costs[t, r])
-                == AC(m.relative_abatement[t, r], m, t, r) * m.baseline[t, r],
+                #sector-feature
+                == AC(m.relative_abatement[t, r], m, t, r) * m.baseline_other[t, r],
+                # == AC(m.relative_abatement[t, r], m, t, r) * m.baseline[t, r],
                 "mitigation_costs",
             ),
         ]

--- a/mimosa/concrete_model/instantiate_params.py
+++ b/mimosa/concrete_model/instantiate_params.py
@@ -179,6 +179,10 @@ class InstantiatedModel:
             "elasmu": V(params["economics"]["elasmu"]),
             "inequal_aversion": V(params["economics"]["inequal_aversion"]),
             "PRTP": V(params["economics"]["PRTP"]),
+            #sector-feature
+            "industry_scaling_baseline": V(
+                params["industry"]["industry_scaling_baseline"]
+            )
         }
 
         if "custom_mapping" in params["simulation"]:

--- a/mimosa/inputdata/config/config_default.yaml
+++ b/mimosa/inputdata/config/config_default.yaml
@@ -551,3 +551,14 @@ simulation:
     descr: Custom mapping of parameter values or variables
     type: dict
     default:
+
+##################
+
+#sector-feature
+industry:
+  industry_scaling_baseline:
+    descr: Percentage of baseline emissions for industry (temporary parameter)
+    type: float
+    min: 0
+    max: 1
+    default: 0.6

--- a/run.py
+++ b/run.py
@@ -16,6 +16,6 @@ for scaling_industry in [0.2, 0.8]:
 
     model1 = MIMOSA(params)
     model1.solve()
-    model1.save(f"testrun_scaling_{scaling_industry}")
+    model1.save(f"testrun_sector_feature_industry_scaling_{scaling_industry}")
     
 # model1.plot(filename="result")

--- a/run.py
+++ b/run.py
@@ -5,6 +5,17 @@ params = load_params()
 # Make changes to the params if needed
 params["emissions"]["carbonbudget"] = False
 
-model1 = MIMOSA(params)
-model1.solve()
-model1.save("run1")
+# model1 = MIMOSA(params)
+# model1.solve()
+# model1.save("run1")
+
+#sector-feature
+for scaling_industry in [0.2, 0.8]:
+    params["industry"]["industry_scaling_baseline"] = scaling_industry
+    params["emissions"]["baseline carbon intensity"] = False
+
+    model1 = MIMOSA(params)
+    model1.solve()
+    model1.save(f"testrun_scaling_{scaling_industry}")
+    
+# model1.plot(filename="result")


### PR DESCRIPTION
merging initial sector modeling into Mimosa+
- baseline emissions are split into Industry and Other sector based on global scaling factor
- Industry emissions are NOT optimized
- mitigation is applied as-is (i.e., not recalibrated) on Other sector baseline emissions